### PR TITLE
Handlers should all return after writing http error

### DIFF
--- a/cmd/api/handlers.go
+++ b/cmd/api/handlers.go
@@ -31,6 +31,7 @@ func (app *application) createAuth(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&creds)
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 	defer r.Body.Close()
 
@@ -136,6 +137,7 @@ func (app *application) partialUpdateUser(w http.ResponseWriter, r *http.Request
 
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 
 	user, err = app.users.Update(user)
@@ -172,6 +174,7 @@ func (app *application) getUser(w http.ResponseWriter, r *http.Request) {
 	user.Permissions, err = app.users.GetPermissions(int(user.ID))
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 
 	app.jsonResponse(w, user)
@@ -209,6 +212,7 @@ func (app *application) listUser(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 
 	meta := make(map[string]interface{})
@@ -395,12 +399,14 @@ func (app *application) createStore(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 
 	err = json.Unmarshal(b, &store)
 
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 
 	// Geocode the store
@@ -504,6 +510,7 @@ func (app *application) listStore(w http.ResponseWriter, r *http.Request) {
 	stores, err := app.stores.List(limit, offset, sb)
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 
 	meta := make(map[string]interface{})
@@ -634,6 +641,7 @@ func (app *application) createFlavor(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 	defer r.Body.Close()
 
@@ -696,6 +704,7 @@ func (app *application) listFlavor(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 
 	meta := make(map[string]interface{})
@@ -750,6 +759,7 @@ func (app *application) listIngredient(w http.ResponseWriter, r *http.Request) {
 		}
 		if err != nil {
 			app.serverError(w, err)
+			return
 		}
 		terms = r
 	}
@@ -757,6 +767,7 @@ func (app *application) listIngredient(w http.ResponseWriter, r *http.Request) {
 	ingredients, err := app.ingredients.Search(limit, offset, sb, terms)
 	if err != nil {
 		app.serverError(w, err)
+		return
 	}
 
 	meta := make(map[string]interface{})

--- a/cmd/api/handlers_test.go
+++ b/cmd/api/handlers_test.go
@@ -202,6 +202,25 @@ func TestGetUser(t *testing.T) {
 	}
 }
 
+func TestDeleteUser(t *testing.T) {
+	app := newTestApplication(t)
+	ts := newTestServer(t, app.routes())
+	defer ts.Close()
+
+	id, err := uuid.NewRandom()
+	if err != nil {
+		t.Error(err)
+	}
+
+	urlPath := fmt.Sprintf("/api/v1/user/%s", id)
+
+	code, _, _ := ts.request(t, "delete", urlPath, bytes.NewBuffer(nil), true)
+
+	if code != http.StatusNoContent {
+		t.Errorf("want %d; got %d", http.StatusNoContent, code)
+	}
+}
+
 func TestGetStore(t *testing.T) {
 	app := newTestApplication(t)
 	ts := newTestServer(t, app.routes())


### PR DESCRIPTION
Resolves #50 

This is pretty straightforward....http handers that write an error out should immediately halt operation and return. This adds return statements after all http errors.