### PR TITLE
57-remove-init-func

### DIFF
--- a/pkg/models/mysql/testutils_test.go
+++ b/pkg/models/mysql/testutils_test.go
@@ -10,19 +10,13 @@ import (
 	"time"
 )
 
-var dsn string
-
-func init() {
-	if os.Getenv("TEST_DSN") != "" {
-		dsn = os.Getenv("TEST_DSN")
-	} else {
-		if !testing.Short() {
-			panic("No test DSN defined")
-		}
-	}
-}
-
 func newTestDB(t *testing.T) (*sql.DB, func()) {
+	var dsn string
+
+	dsn = os.Getenv("TEST_DSN")
+	if dsn == "" && !testing.Short() {
+		t.Fatal("No test DSN defined")
+	}
 
 	db, err := sql.Open("mysql", dsn)
 


### PR DESCRIPTION
Removes the init function and moves it's operations to the newTestDB func.